### PR TITLE
Update pfp and trkg4id

### DIFF
--- a/duneana/AnaTree/AnalysisTree.fcl
+++ b/duneana/AnaTree/AnalysisTree.fcl
@@ -60,6 +60,7 @@ dune35t_analysistree:
  SaveCnnInfo:              false
  SavePFParticleInfo:       true
  G4minE:                   -1
+ RollUpUnsavedIDs:         true
 }
 
 protodune_analysistree:   @local::dune35t_analysistree

--- a/duneana/AnaTree/CMakeLists.txt
+++ b/duneana/AnaTree/CMakeLists.txt
@@ -6,6 +6,7 @@ art_make( MODULE_LIBRARIES
 	  lardataobj::Simulation
 	  larsim::MCCheater_BackTrackerService_service
 	  larsim::MCCheater_ParticleInventoryService_service
+          larsim::Utils
 	  lardata::Utilities
 	  larevt::Filters
 	  lardataobj::RawData


### PR DESCRIPTION
 ## Changed track to MCTruth ID to use TruthMatchUtils

Changed the way to compute completeness.
Cicle all hits only once when start to save tracks.

 ## Fix PFP for tracks and showers

Shower's ID is always stored as -999 (at the art root file level). To fix
this, instead of using the map between PFP and ShowerID, I use the
association and create the showerID when looping through the showers.

I also updated the selection isTrack and isShower, to deal with the fact
that both recob::Tracks and recob::Showers have all PFParticles stored.