### PR TITLE
Filling more ereco variables. Adding some hotfix to deal with the atm CVN

### DIFF
--- a/duneana/CAFMaker/CAFMaker.fcl
+++ b/duneana/CAFMaker/CAFMaker.fcl
@@ -6,10 +6,13 @@ dunefd_cafmaker:
     CreateFlatCAF:              true
 
     CVNLabel:                   "cvneva:cvnresult"
+    IsAtmoCVN:                  false #Hotfix to take care of the fact that the CVN for atmospherics is storing results in a weird way...
     RegCNNLabel:                "regcnneval"
-    EnergyRecoNueLabel:         "energyrecnue"
-    EnergyRecoNumuLabel:        "energyrecnumu"
-    EnergyRecoNCLabel:          "energyrecnc"
+    EnergyRecoCaloLabel:        "energyrecnc"
+    EnergyRecoLepCaloLabel:     "energyrecnumu"
+    EnergyRecoMuRangeLabel:     "energyrecnumurange"
+    EnergyRecoMuMcsLabel:       "energyrecnumumcs"
+    EnergyRecoECaloLabel:       "energyrecnue"
     DirectionRecoLabelNue:      "anglereconuepfps"
     DirectionRecoLabelNumu:     "anglereconumupfps"
     PandoraNuVertexModuleLabel: "pandora"


### PR DESCRIPTION
Minor changes to:
- Fill new energy reco records that were added to the CAF format
- Address the issue of the atmospherics CVN results being stored in a specific way in the `cvn::Result` object.