### PR TITLE
v10 geometry refactoring upgrade -- re-add CalibAna directory to build

### DIFF
--- a/duneana/CMakeLists.txt
+++ b/duneana/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(AnaTree)
 add_subdirectory(CAFMaker)
-#add_subdirectory(CalibAna)
+add_subdirectory(CalibAna)
 add_subdirectory(DAQSimAna)
 add_subdirectory(EnergyStudies)
 add_subdirectory(EventFilters)

--- a/duneana/CalibAna/CalibAnaTree.h
+++ b/duneana/CalibAna/CalibAnaTree.h
@@ -55,9 +55,8 @@
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
-#include "larcore/Geometry/Geometry.h"
 #include "larcore/CoreUtils/ServiceUtil.h"
-#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/Geometry/fwd.h"
 
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "larsim/MCCheater/BackTrackerService.h"
@@ -127,7 +126,7 @@ private:
     const std::vector<art::Ptr<anab::Calorimetry>> &calo,
     const std::map<geo::WireID, art::Ptr<raw::RawDigit>> &rawdigits,
     const std::vector<GlobalTrackInfo> &tracks,
-    const geo::GeometryCore *geo,
+    const geo::WireReadoutGeom *wireReadout,
     const detinfo::DetectorClocksData &clock_data,
     const cheat::BackTrackerService *bt_serv,
     const dune::EDet det);
@@ -138,6 +137,7 @@ private:
     const art::FindManyP<recob::SpacePoint> &PFParticleSPs);
 
   void FillTrackEndHits(const geo::GeometryCore *geometry,
+    const geo::WireReadoutGeom *wireReadout,
     const detinfo::DetectorPropertiesData &dprop,
     const recob::Track &track,
     const std::vector<art::Ptr<recob::Hit>> &allHits,
@@ -151,7 +151,8 @@ private:
     const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map,
     const std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map,
     const detinfo::DetectorPropertiesData &dprop,
-    const geo::GeometryCore *geo);
+    const geo::GeometryCore *geo,
+    const geo::WireReadoutGeom *wireReadout);
 
   TrackHitInfo MakeHit(const recob::Hit &hit,
     unsigned hkey,
@@ -159,7 +160,7 @@ private:
     const recob::Track &trk,
     const art::Ptr<recob::SpacePoint> &sp,
     const std::vector<art::Ptr<anab::Calorimetry>> &calo,
-    const geo::GeometryCore *geo,
+    const geo::WireReadoutGeom *wireReadout,
     const detinfo::DetectorClocksData &dclock,
     const cheat::BackTrackerService *bt_serv);
 
@@ -168,7 +169,7 @@ private:
     // declare truth utils, ported from CAFana in SBNCode
     std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>>
     PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels,
-		    const geo::GeometryCore &geo);
+		    const geo::WireReadoutGeom &geo);
     std::map<int, std::vector<art::Ptr<recob::Hit>>>
     PrepTrueHits(const std::vector<art::Ptr<recob::Hit>> &allHits,
 		 const detinfo::DetectorClocksData &clockData,

--- a/duneana/CalibAna/CalibAnaTree_module.cc
+++ b/duneana/CalibAna/CalibAnaTree_module.cc
@@ -14,6 +14,10 @@
 #include "CalibAnaTree.h"
 #include "G4processUtil.h"
 
+#include "larcore/Geometry/WireReadout.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
+
 // Global functions / data for fitting
 const size_t MAX_N_FIT_DATA = 30;
 
@@ -122,16 +126,17 @@ void dune::CalibAnaTree::analyze(art::Event const& e)
 
   // Services
   const geo::GeometryCore *geometry = lar::providerFrom<geo::Geometry>();
+  const geo::WireReadoutGeom *wireReadout = &art::ServiceHandle<geo::WireReadout>()->Get();
   auto const clock_data = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e);
   auto const dprop =
     art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(e, clock_data);
 
   // Identify which detector: can only detect either sbnd or icarus
-
-  std::string gdml = geometry->GDMLFile();
-  gdml = basename(gdml.c_str());
-
-  for(unsigned int i = 0; i <gdml.size(); ++i) gdml[i] = std::tolower(gdml[i]);
+  // Viktor Pec copied this for DUNE..  gdml seems ignored
+  
+  //std::string gdml = geometry->GDMLFile();
+  //gdml = basename(gdml.c_str());
+  //for(unsigned int i = 0; i <gdml.size(); ++i) gdml[i] = std::tolower(gdml[i]);
 
   EDet det = kNOTDEFINED;
 
@@ -228,7 +233,7 @@ void dune::CalibAnaTree::analyze(art::Event const& e)
     std::vector<geo::WireID> wids;
     // Handle bad channel ID
     try {
-      wids = geometry->ChannelToWire(d->Channel());
+      wids = wireReadout->ChannelToWire(d->Channel());
     }
     catch(...) {
       //Fail if something...fails...
@@ -267,7 +272,7 @@ void dune::CalibAnaTree::analyze(art::Event const& e)
 
   if (simchannels.size()) {
     art::ServiceHandle<cheat::BackTrackerService> bt_serv;
-    id_to_ide_map = PrepSimChannels(simchannels, *geometry);
+    id_to_ide_map = PrepSimChannels(simchannels, *wireReadout);
     id_to_truehit_map = PrepTrueHits(allHits, clock_data, *bt_serv.get());
     bt = bt_serv.get();
   }
@@ -343,15 +348,15 @@ void dune::CalibAnaTree::analyze(art::Event const& e)
     fWiresToSave.clear();
 
     // Fill the track!
-    FillTrack(*trkPtr, pfp, t0, trkHits, trkHitMetas, trkHitSPs, calo, rawdigits, track_infos, geometry, clock_data, bt, det);
+    FillTrack(*trkPtr, pfp, t0, trkHits, trkHitMetas, trkHitSPs, calo, rawdigits, track_infos, wireReadout, clock_data, bt, det);
     fTrack->whicht0 = whicht0;
 
     FillTrackDaughterRays(*trkPtr, pfp, PFParticleList, PFParticleSPs);
 
-    if (fFillTrackEndHits) FillTrackEndHits(geometry, dprop, *trkPtr, allHits, allHitSPs);
+    if (fFillTrackEndHits) FillTrackEndHits(geometry, wireReadout, dprop, *trkPtr, allHits, allHitSPs);
 
     // Fill the truth information if configured
-    if (simchannels.size()) FillTrackTruth(clock_data, trkHits, mcparticles, AVs, TPCVols, id_to_ide_map, id_to_truehit_map, dprop, geometry);
+    if (simchannels.size()) FillTrackTruth(clock_data, trkHits, mcparticles, AVs, TPCVols, id_to_ide_map, id_to_truehit_map, dprop, geometry, wireReadout);
 
     // Save?
     bool select = false;
@@ -389,14 +394,13 @@ dune::Vector3D ConvertTVector(const TVector3 &tv) {
 }
 
 // Turn a particle position to a space-charge induced position
-geo::Point_t TrajectoryToWirePosition(const geo::Point_t &loc, const geo::TPCID &tpc) {
+geo::Point_t TrajectoryToWirePosition(const geo::Point_t &loc, const geo::Vector_t& driftdir) {
   auto const* sce = lar::providerFrom<spacecharge::SpaceChargeService>();
-  art::ServiceHandle<geo::Geometry const> geom;
 
   geo::Point_t ret = loc;
 
   // Returned X is the drift -- multiply by the drift direction to undo this
-  int corr = geom->TPC(tpc).DriftDir().X();
+  int corr = driftdir.X();
 
   if (sce && sce->EnableSimSpatialSCE()) {
     geo::Vector_t offset = sce->GetPosOffsets(ret);
@@ -434,7 +438,8 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
 				    const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE *>>> &id_to_ide_map,
 				    const std::map<int, std::vector<art::Ptr<recob::Hit>>> &id_to_truehit_map,
 				    const detinfo::DetectorPropertiesData &dprop,
-				    const geo::GeometryCore *geo) {
+				    const geo::GeometryCore *geo,
+				    const geo::WireReadoutGeom *wireReadout) {
 
   std::vector<std::pair<geo::WireID, const sim::IDE *>> empty;
   const std::vector<std::pair<geo::WireID, const sim::IDE *>> &particle_ides = id_to_ide_map.count(particle.TrackId()) ? id_to_ide_map.at(particle.TrackId()) : empty;
@@ -597,7 +602,7 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
 
   for (auto const &ide_pair: particle_ides) {
     const geo::WireID &w = ide_pair.first;
-    unsigned c = geo->PlaneWireToChannel(w);
+    unsigned c = wireReadout->PlaneWireToChannel(w);
     const sim::IDE *ide = ide_pair.second;
 
     // Set stuff
@@ -631,7 +636,7 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
   // Compute widths
   for (auto const &ide_pair: particle_ides) {
     const geo::WireID &w = ide_pair.first;
-    unsigned c = geo->PlaneWireToChannel(w);
+    unsigned c = wireReadout->PlaneWireToChannel(w);
     const sim::IDE *ide = ide_pair.second;
 
     geo::Point_t ide_p(ide->x, ide->y, ide->z);
@@ -659,7 +664,7 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
   for (dune::TrueHit &h: truehits_v) {
     h.time = dprop.ConvertXToTicks(h.p.x, h.plane, h.tpc, h.cryo);
 
-    double xdrift = abs(h.p.x - geo->Plane(geo::PlaneID(h.cryo, h.tpc, 0)).GetCenter().X());
+    double xdrift = abs(h.p.x - wireReadout->Plane(geo::PlaneID(h.cryo, h.tpc, 0)).GetCenter().X());
     h.tdrift = xdrift / dprop.DriftVelocity();
   }
 
@@ -682,9 +687,10 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
     // If we got a direction, get the pitch
     if (closest_dist >= 0. && direction.Mag() > 1e-4) {
       geo::PlaneID plane(h.cryo, h.tpc, h.plane);
-      float angletovert = geo->WireAngleToVertical(geo->View(plane), plane) - 0.5*::util::pi<>();
+      geo::PlaneGeo const& planeGeo = wireReadout->Plane(plane);
+      float angletovert = wireReadout->WireAngleToVertical(planeGeo.View(), plane) - 0.5*::util::pi<>();
       float cosgamma = abs(cos(angletovert) * direction.Z() + sin(angletovert) * direction.Y());
-      float pitch = geo->WirePitch(plane) / cosgamma;
+      float pitch = planeGeo.WirePitch() / cosgamma;
       h.pitch = pitch;
     }
     else {
@@ -693,18 +699,20 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
     // And the pitch induced by SCE
     if (closest_dist >= 0. && direction.Mag() > 1e-4) {
       geo::PlaneID plane(h.cryo, h.tpc, h.plane);
-      float angletovert = geo->WireAngleToVertical(geo->View(plane), plane) - 0.5*::util::pi<>();
-
-      TVector3 loc_mdx_v = h_p - direction * (geo->WirePitch(geo->View(plane)) / 2.);
-      TVector3 loc_pdx_v = h_p + direction * (geo->WirePitch(geo->View(plane)) / 2.);
+      geo::PlaneGeo const& planeGeo = wireReadout->Plane(plane);
+      float angletovert = wireReadout->WireAngleToVertical(planeGeo.View(), plane) - 0.5*::util::pi<>();
+      
+      TVector3 loc_mdx_v = h_p - direction * (planeGeo.WirePitch() / 2.);
+      TVector3 loc_pdx_v = h_p + direction * (planeGeo.WirePitch() / 2.);
 
       // Convert types for helper functions
       geo::Point_t loc_mdx(loc_mdx_v.X(), loc_mdx_v.Y(), loc_mdx_v.Z());
       geo::Point_t loc_pdx(loc_pdx_v.X(), loc_pdx_v.Y(), loc_pdx_v.Z());
       geo::Point_t h_p_point(h_p.X(), h_p.Y(), h_p.Z());
 
-      loc_mdx = TrajectoryToWirePosition(loc_mdx, plane);
-      loc_pdx = TrajectoryToWirePosition(loc_pdx, plane);
+      auto const driftdir = geo->TPC(plane).DriftDir();
+      loc_mdx = TrajectoryToWirePosition(loc_mdx, driftdir);
+      loc_pdx = TrajectoryToWirePosition(loc_pdx, driftdir);
 
       // Direction at wires
       geo::Vector_t dir = (loc_pdx - loc_mdx) /  (loc_mdx - loc_pdx).r();
@@ -713,14 +721,14 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
       double cosgamma = std::abs(std::sin(angletovert)*dir.Y() + std::cos(angletovert)*dir.Z());
       double pitch;
       if (cosgamma) {
-	pitch = geo->WirePitch(geo->View(plane))/cosgamma;
+	pitch = planeGeo.WirePitch()/cosgamma;
       }
       else {
 	pitch = 0.;
       }
 
       // Now bring that back to the particle trajectory
-      geo::Point_t loc_w = TrajectoryToWirePosition(h_p_point, plane);
+      geo::Point_t loc_w = TrajectoryToWirePosition(h_p_point, driftdir);
 
       geo::Point_t locw_pdx_traj = WireToTrajectoryPosition(loc_w + pitch*dir, plane);
       geo::Point_t loc = WireToTrajectoryPosition(loc_w, plane);
@@ -774,19 +782,19 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
     geo::Point_t traj_p(traj.X(), traj.Y(), traj.Z());
 
     // lookup TPC
-    geo::TPCID tpc; // invalid by default
+    geo::TPCGeo const* tpc{nullptr}; // invalid by default
     for (auto const &cryo: geo->Iterate<geo::CryostatGeo>()) {
       for (auto const& TPC : geo->Iterate<geo::TPCGeo>(cryo.ID())) {
 	if (TPC.ActiveBoundingBox().ContainsPosition(traj_p)) {
-	  tpc = TPC.ID();
+	  tpc = &TPC;
 	  break;
 	}
       }
-      if (tpc.isValid) break;
+      if (tpc && tpc->ID().isValid) break;
     }
 
     // add in space-charge-deflected position if applicable
-    geo::Point_t traj_p_sce = tpc.isValid ? TrajectoryToWirePosition(traj_p, tpc) : traj_p;
+    geo::Point_t traj_p_sce = tpc ? TrajectoryToWirePosition(traj_p, tpc->DriftDir()) : traj_p;
 
     dune::Vector3D traj_v;
     traj_v.x = traj_p.x();
@@ -806,6 +814,7 @@ dune::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
 }
 
 void dune::CalibAnaTree::FillTrackEndHits(const geo::GeometryCore *geometry,
+					  const geo::WireReadoutGeom *wireReadout,
 					  const detinfo::DetectorPropertiesData &dprop,
 					  const recob::Track &track,
 					  const std::vector<art::Ptr<recob::Hit>> &allHits,
@@ -818,7 +827,7 @@ void dune::CalibAnaTree::FillTrackEndHits(const geo::GeometryCore *geometry,
 
   geo::PlaneID plane_end(tpc_end, 2 /* collection */);
 
-  float end_w = geometry->WireCoordinate(track.End(), plane_end);
+  float end_w = wireReadout->Plane(plane_end).WireCoordinate(track.End());
 
   float end_t = -1000.;
   float closest_wire_dist = -1.;
@@ -885,7 +894,8 @@ void dune::CalibAnaTree::FillTrackTruth(const detinfo::DetectorClocksData &clock
 					const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map,
 					const std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map,
 					const detinfo::DetectorPropertiesData &dprop,
-					const geo::GeometryCore *geo) {
+					const geo::GeometryCore *geo,
+					const geo::WireReadoutGeom *wireReadout) {
 
   // Lookup the true-particle match -- use utils ported from SBNCode CAF
   std::vector<std::pair<int, float>> matches = AllTrueParticleIDEnergyMatches(clock_data, trkHits, true);
@@ -917,7 +927,7 @@ void dune::CalibAnaTree::FillTrackTruth(const detinfo::DetectorClocksData &clock
 	    std::cout << "Matched! G4 Track ID: " << p_mcp->TrackId()
 		      << " pdg: " << p_mcp->PdgCode()
 		      << " process: " << p_mcp->EndProcess() << std::endl;
-	fTrack->truth.p = TrueParticleInfo(*p_mcp, active_volumes, tpc_volumes, id_to_ide_map, id_to_truehit_map, dprop, geo);
+	fTrack->truth.p = TrueParticleInfo(*p_mcp, active_volumes, tpc_volumes, id_to_ide_map, id_to_truehit_map, dprop, geo, wireReadout);
 	fTrack->truth.eff = fTrack->truth.depE / (fTrack->truth.p.plane0VisE + fTrack->truth.p.plane1VisE + fTrack->truth.p.plane2VisE);
 
 	// Lookup any Michel
@@ -926,7 +936,7 @@ void dune::CalibAnaTree::FillTrackTruth(const detinfo::DetectorClocksData &clock
 	      (d_mcp->Process() == "Decay" || d_mcp->Process() == "muMinusCaptureAtRest") && // correct process
 	      abs(d_mcp->PdgCode()) == 11) { // correct PDG code
 
-	    fTrack->truth.michel = TrueParticleInfo(*d_mcp, active_volumes, tpc_volumes, id_to_ide_map, id_to_truehit_map, dprop, geo);
+	    fTrack->truth.michel = TrueParticleInfo(*d_mcp, active_volumes, tpc_volumes, id_to_ide_map, id_to_truehit_map, dprop, geo, wireReadout);
 	    break;
 	  }
 	}
@@ -971,7 +981,7 @@ void dune::CalibAnaTree::FillTrack(const recob::Track &track,
 				   const std::vector<art::Ptr<anab::Calorimetry>> &calo,
 				   const std::map<geo::WireID, art::Ptr<raw::RawDigit>> &rawdigits,
 				   const std::vector<GlobalTrackInfo> &tracks,
-				   const geo::GeometryCore *geo,
+				   const geo::WireReadoutGeom *wireReadout,
 				   const detinfo::DetectorClocksData &clock_data,
 				   const cheat::BackTrackerService *bt_serv,
 				   const dune::EDet det) {
@@ -999,7 +1009,7 @@ void dune::CalibAnaTree::FillTrack(const recob::Track &track,
 
   // Fill each hit
   for (unsigned i_hit = 0; i_hit < hits.size(); i_hit++) {
-    dune::TrackHitInfo hinfo = MakeHit(*hits[i_hit], hits[i_hit].key(), *thms[i_hit], track, sps[i_hit], calo, geo, clock_data, bt_serv);
+    dune::TrackHitInfo hinfo = MakeHit(*hits[i_hit], hits[i_hit].key(), *thms[i_hit], track, sps[i_hit], calo, wireReadout, clock_data, bt_serv);
     if (hinfo.h.plane == 0) {
       fTrack->hits0.push_back(hinfo);
     }
@@ -1033,7 +1043,7 @@ void dune::CalibAnaTree::FillTrack(const recob::Track &track,
       winfo.wire = wire.Wire;
       winfo.plane = wire.Plane;
       winfo.tpc = wire.TPC;
-      winfo.channel = geo->PlaneWireToChannel(wire);
+      winfo.channel = wireReadout->PlaneWireToChannel(wire);
       winfo.tdc0 = min_tick;
       winfo.adcs = adcs;
 
@@ -1147,7 +1157,7 @@ dune::TrackHitInfo dune::CalibAnaTree::MakeHit(const recob::Hit &hit,
 					       const recob::Track &trk,
 					       const art::Ptr<recob::SpacePoint> &sp,
 					       const std::vector<art::Ptr<anab::Calorimetry>> &calo,
-					       const geo::GeometryCore *geo,
+					       const geo::WireReadoutGeom *wireReadout,
 					       const detinfo::DetectorClocksData &dclock,
 					       const cheat::BackTrackerService *bt_serv) {
 
@@ -1162,7 +1172,7 @@ dune::TrackHitInfo dune::CalibAnaTree::MakeHit(const recob::Hit &hit,
   hinfo.h.mult = hit.Multiplicity();
   hinfo.h.wire = hit.WireID().Wire;
   hinfo.h.plane = hit.WireID().Plane;
-  hinfo.h.channel = geo->PlaneWireToChannel(hit.WireID());
+  hinfo.h.channel = wireReadout->PlaneWireToChannel(hit.WireID());
   hinfo.h.tpc = hit.WireID().TPC;
   hinfo.h.end = hit.EndTick();
   hinfo.h.start = hit.StartTick();
@@ -1279,7 +1289,7 @@ dune::TrackHitInfo dune::CalibAnaTree::MakeHit(const recob::Hit &hit,
 
 /// Code taken from sbncode/CAFMaker/FillTrue.cxx
 std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> dune::CalibAnaTree::PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels,
-												   const geo::GeometryCore &geo)
+												   const geo::WireReadoutGeom &geo)
 /// Creates map of WireID and sim::IDE by backtracked track ID
 {
   std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> ret;


### PR DESCRIPTION
I found that Viktor Pec had copied SBND's TrackCaloSkimmer_module.cc here as CalibAnaTree_module.cc, and that Kyle had already upgraded that to the v10 refactored geometry API in LArSoft.  

https://github.com/SBNSoftware/sbncode/pull/393/commits/e0c4f5b96d50fc98d5a654298ccef5d093d1eb2d#diff-ad9b921e07635a58d46230a8bdd9470ecc16f1412548dfc067538d49049e73c9

I applied the changes in there, added the CalibAna directory back to the parent directory's CMakeLists.txt file, and got it to compile. 