### PR TITLE
FD CAFMaker update

### DIFF
--- a/duneana/CAFMaker/CAFMaker.fcl
+++ b/duneana/CAFMaker/CAFMaker.fcl
@@ -1,3 +1,5 @@
+#include "calorimetry_dune10kt.fcl"
+
 BEGIN_PROLOG
 
 dunefd_cafmaker:
@@ -15,15 +17,22 @@ dunefd_cafmaker:
     EnergyRecoECaloLabel:       "energyrecnue"
     DirectionRecoLabelNue:      "anglereconuepfps"
     DirectionRecoLabelNumu:     "anglereconumupfps"
-    PandoraNuVertexModuleLabel: "pandora"
+    PandoraLabel:               "pandora"
+    ParticleIDLabel:            "pmtrackpid"
     MCTruthLabel:               "generator"
     GTruthLabel:                "generator"
     MCFluxLabel:                "generator"
     POTSummaryLabel:            "generator"
+    TrackLabel:                 "pandoraTrack"
+    ShowerLabel:                "pandoraShower"
+    SpacePointLabel:            "pandora"
+    HitLabel:                   "TODO:LABEL"
 
-    FidVolCut:	             3.0
-    NuECut:                  0.8
-    NuMuCut:                 0.8
+    FiducialVolumeCut:          [ 20, 20, 20, 20, 20, 20 ] #FV cut margins for all directions minX, maxX, minY, maxY, minZ, maxZ (in cm)
+    ContainedDistThreshold:     20 #Distance from the edge of the AV to be considered contained (in cm)
+
+    CalorimetryAlg:             @local::dune10kt_calorimetryalgmc
+    RecombFactor:               0.63 #Average recombination factor used the the hits not attached to a PFP
     
 }
 

--- a/duneana/CAFMaker/CAFMaker.fcl
+++ b/duneana/CAFMaker/CAFMaker.fcl
@@ -38,4 +38,10 @@ dunefd_cafmaker:
     
 }
 
+dunefdvd_cafmaker:
+{
+    @table::dunefd_cafmaker
+    HitLabel: "gaushit"
+}
+
 END_PROLOG

--- a/duneana/CAFMaker/CAFMaker.fcl
+++ b/duneana/CAFMaker/CAFMaker.fcl
@@ -17,8 +17,9 @@ dunefd_cafmaker:
     EnergyRecoECaloLabel:       "energyrecnue"
     DirectionRecoLabelNue:      "anglereconuepfps"
     DirectionRecoLabelNumu:     "anglereconumupfps"
+    DirectionRecoLabelCalo:     "anglerecohits"
     PandoraLabel:               "pandora"
-    ParticleIDLabel:            "pmtrackpid"
+    ParticleIDLabel:            "pandorapid"
     MCTruthLabel:               "generator"
     GTruthLabel:                "generator"
     MCFluxLabel:                "generator"
@@ -26,9 +27,9 @@ dunefd_cafmaker:
     TrackLabel:                 "pandoraTrack"
     ShowerLabel:                "pandoraShower"
     SpacePointLabel:            "pandora"
-    HitLabel:                   "TODO:LABEL"
+    HitLabel:                   "hitfd"
 
-    FiducialVolumeCut:          [ 20, 20, 20, 20, 20, 20 ] #FV cut margins for all directions minX, maxX, minY, maxY, minZ, maxZ (in cm)
+    VertexFiducialVolumeCut:    [ 20, 20, 20, 20, 20, 20 ] #FV cut margins for all directions minX, maxX, minY, maxY, minZ, maxZ (in cm)
     ContainedDistThreshold:     20 #Distance from the edge of the AV to be considered contained (in cm)
 
     CalorimetryAlg:             @local::dune10kt_calorimetryalgmc

--- a/duneana/CAFMaker/CAFMaker.fcl
+++ b/duneana/CAFMaker/CAFMaker.fcl
@@ -14,6 +14,7 @@ dunefd_cafmaker:
     EnergyRecoLepCaloLabel:     "energyrecnumu"
     EnergyRecoMuRangeLabel:     "energyrecnumurange"
     EnergyRecoMuMcsLabel:       "energyrecnumumcs"
+    EnergyRecoMuMcsLLHDLabel:   "energyrecnumumcsllhd"
     EnergyRecoECaloLabel:       "energyrecnue"
     DirectionRecoLabelNue:      "anglereconuepfps"
     DirectionRecoLabelNumu:     "anglereconumupfps"

--- a/duneana/CAFMaker/CAFMaker.fcl
+++ b/duneana/CAFMaker/CAFMaker.fcl
@@ -28,6 +28,7 @@ dunefd_cafmaker:
     ShowerLabel:                "pandoraShower"
     SpacePointLabel:            "pandora"
     HitLabel:                   "hitfd"
+    G4Label:                    "largeant"
 
     VertexFiducialVolumeCut:    [ 20, 20, 20, 20, 20, 20 ] #FV cut margins for all directions minX, maxX, minY, maxY, minZ, maxZ (in cm)
     ContainedDistThreshold:     20 #Distance from the edge of the AV to be considered contained (in cm)

--- a/duneana/CAFMaker/CAFMaker_module.cc
+++ b/duneana/CAFMaker/CAFMaker_module.cc
@@ -125,6 +125,7 @@ namespace caf {
       std::string fEnergyRecoLepCaloLabel;
       std::string fEnergyRecoMuRangeLabel;
       std::string fEnergyRecoMuMcsLabel;
+      std::string fEnergyRecoMuMcsLLHDLabel;
       std::string fEnergyRecoECaloLabel;
       std::string fDirectionRecoLabelNue;
       std::string fDirectionRecoLabelNumu;
@@ -193,6 +194,7 @@ namespace caf {
       fEnergyRecoLepCaloLabel(pset.get<std::string>("EnergyRecoLepCaloLabel")),
       fEnergyRecoMuRangeLabel(pset.get<std::string>("EnergyRecoMuRangeLabel")),
       fEnergyRecoMuMcsLabel(pset.get<std::string>("EnergyRecoMuMcsLabel")),
+      fEnergyRecoMuMcsLLHDLabel(pset.get<std::string>("EnergyRecoMuMcsLLHDLabel")),
       fEnergyRecoECaloLabel(pset.get<std::string>("EnergyRecoECaloLabel")),
       fDirectionRecoLabelNue(pset.get<std::string>("DirectionRecoLabelNue")),
       fDirectionRecoLabelNumu(pset.get<std::string>("DirectionRecoLabelNumu")),
@@ -880,6 +882,7 @@ namespace caf {
       {fEnergyRecoLepCaloLabel, &(ErecBranch.lep_calo)},
       {fEnergyRecoMuRangeLabel, &(ErecBranch.mu_range)},
       {fEnergyRecoMuMcsLabel, &(ErecBranch.mu_mcs)},
+      {fEnergyRecoMuMcsLLHDLabel, &(ErecBranch.mu_mcs_llhd)},
       {fEnergyRecoECaloLabel, &(ErecBranch.e_calo)}
     };
 

--- a/duneana/CAFMaker/CMakeLists.txt
+++ b/duneana/CAFMaker/CMakeLists.txt
@@ -29,6 +29,7 @@ cet_build_plugin(CAFMaker   art::module LIBRARIES
 			larpandora::LArPandoraInterface
                         larreco::Calorimetry
                         dunereco::AnaUtils
+                        larsim::Utils
               BASENAME_ONLY
 )
 endif()

--- a/duneana/CAFMaker/CMakeLists.txt
+++ b/duneana/CAFMaker/CMakeLists.txt
@@ -27,6 +27,8 @@ cet_build_plugin(CAFMaker   art::module LIBRARIES
 			systematicstools::utility
                         dunereco::CVN_func
 			larpandora::LArPandoraInterface
+                        larreco::Calorimetry
+                        dunereco::AnaUtils
               BASENAME_ONLY
 )
 endif()


### PR DESCRIPTION
Rather large FD CAFMaker update to add more information newly introduced in the CAF format as well as saving the reconstructed particles.

What is newly implemented:
- The reconstructed pandora PFP are now saved in the CAFs
- The associated Track and Shower are saved in parallel to allow for an easy parallel matching through index
- All the hits non associated to a PFP are collected in a special HitCollection object that allows to save their energy (can be useful for some studies)
- Hadronic energy is saved to be able to recombine had and lep energy as required during analyses
- Adding the calorimetric direction reconstruction method
- Adding some containment information
- Some minor nuclear interaction information are fixed

What is not implemented:
- True/Reco matching. Can be done if required, but would be good to know which level of backtracking people need. For now only the primary true particles are saved.
- A specific Energy/Momentum/PID decision for tracks. The PIDA score is saved but no choice is made for the final analyzer. The best would be to have some dedicated module the user can configure and provide to return PID/Energy/Momentum by making the decisions wanted by the user.
