### PR TITLE
ADD PROJECTION OPTION FOR MEMPLANE XA FLASHMATCH

### DIFF
--- a/duneana/SolarNuAna/SolarNuAna_module.cc
+++ b/duneana/SolarNuAna/SolarNuAna_module.cc
@@ -87,6 +87,7 @@ namespace solar
     bool fClusterPreselectionSignal, fClusterPreselectionPrimary, fClusterPreselectionTrack, fClusterPreselectionFlashMatch;
     bool fGenerateAdjOpFlash, fFlashMatchByResidual;
     bool fSaveSignalDaughters, fSaveSignalEDep, fSaveSignalOpHits, fSaveOpFlashInfo, fSaveTrackInfo;
+    bool fAdjOpFlashMembraneProjection, fAdjOpFlashEndCapProjection; // If true, the TPC reco is projected to the membrane plane. If false, apply a 3D constraint dT, Y, Z.
     // bool fOpFlashAlgoCentroid;
 
     // --- Our TTrees, and its associated variables.
@@ -193,6 +194,8 @@ namespace solar
     fOpFlashAlgoPE = p.get<float>("OpFlashAlgoPE");
     fOpFlashAlgoTriggerPE = p.get<float>("OpFlashAlgoTriggerPE");
     fOpFlashAlgoHotVertexThld = p.get<float>("OpFlashAlgoHotVertexThld");
+    fAdjOpFlashMembraneProjection = p.get<bool>("AdjOpFlashMembraneProjection");
+    fAdjOpFlashEndCapProjection = p.get<bool>("AdjOpFlashEndCapProjection");
     // fOpFlashAlgoCentroid = p.get<bool>("OpFlashAlgoCentroid");
     // fAdjOpFlashTime = p.get<float>("AdjOpFlashTime");
     fAdjOpFlashX = p.get<float>("AdjOpFlashX");
@@ -255,6 +258,8 @@ namespace solar
     fConfigTree->Branch("OpFlashAlgoPE", &fOpFlashAlgoPE);
     fConfigTree->Branch("OpFlashAlgoTriggerPE", &fOpFlashAlgoTriggerPE);
     fConfigTree->Branch("OpFlashAlgoHotVertexThld", &fOpFlashAlgoHotVertexThld);
+    fConfigTree->Branch("AdjOpFlashMembraneProjection", &fAdjOpFlashMembraneProjection);
+    fConfigTree->Branch("AdjOpFlashMembraneProjection", &fAdjOpFlashEndCapProjection);
     // fConfigTree->Branch("OpFlashAlgoCentroid", &fOpFlashAlgoCentroid);
     // fConfigTree->Branch("AdjOpFlashTime", &fAdjOpFlashTime);
     fConfigTree->Branch("AdjOpFlashX", &fAdjOpFlashX);
@@ -1632,17 +1637,29 @@ namespace solar
           }
           else if (fGeometry == "VD" && (OpFlashPlane[j] == 1 || OpFlashPlane[j] == 2)) // Membrane flashes
           {
-            if (pow(MAdjFlashX - OpFlashX[j], 2) / pow(fAdjOpFlashX, 2) + pow(MVecRecZ[i] - OpFlashZ[j], 2) / pow(fAdjOpFlashZ, 2) > 1)
-            {
-              continue;
+            if (fAdjOpFlashMembraneProjection){
+              if (pow(MAdjFlashX - OpFlashX[j], 2) / pow(fAdjOpFlashX, 2) + pow(MVecRecZ[i] - OpFlashZ[j], 2) / pow(fAdjOpFlashZ, 2) > 1){
+                continue;
+              }
+            }
+            else{
+              if (pow(MAdjFlashX - OpFlashX[j], 2) / pow(fAdjOpFlashX, 2) + pow(MVecRecY[i] - OpFlashY[j], 2) / pow(fAdjOpFlashY, 2) + pow(MVecRecZ[i] - OpFlashZ[j], 2) / pow(fAdjOpFlashZ, 2) > 1){
+                continue;
+              }
             }
             OpFlashR = sqrt(pow(MAdjFlashX - OpFlashX[j], 2) + pow(MVecRecZ[i] - OpFlashZ[j], 2));
           } 
           else if (fGeometry == "VD" && (OpFlashPlane[j] == 3 || OpFlashPlane[j] == 4)) // End-Cap flashes
           {
-            if (pow(MAdjFlashX - OpFlashX[j], 2) / pow(fAdjOpFlashX, 2) + pow(MVecRecY[i] - OpFlashY[j], 2) / pow(fAdjOpFlashY, 2) > 1)
-            {
-              continue;
+            if (fAdjOpFlashEndCapProjection){
+              if (pow(MAdjFlashX - OpFlashX[j], 2) / pow(fAdjOpFlashX, 2) + pow(MVecRecY[i] - OpFlashY[j], 2) / pow(fAdjOpFlashY, 2) > 1){
+                continue;
+              }
+            }
+            else{
+              if (pow(MAdjFlashX - OpFlashX[j], 2) / pow(fAdjOpFlashX, 2) + pow(MVecRecY[i] - OpFlashY[j], 2) / pow(fAdjOpFlashY, 2) + pow(MVecRecZ[i] - OpFlashZ[j], 2) / pow(fAdjOpFlashZ, 2) > 1){
+                continue;
+              }
             }
             OpFlashR = sqrt(pow(MAdjFlashX - OpFlashX[j], 2) + pow(MVecRecY[i] - OpFlashY[j], 2));
           }

--- a/duneana/SolarNuAna/SolarNuAna_module.cc
+++ b/duneana/SolarNuAna/SolarNuAna_module.cc
@@ -259,7 +259,7 @@ namespace solar
     fConfigTree->Branch("OpFlashAlgoTriggerPE", &fOpFlashAlgoTriggerPE);
     fConfigTree->Branch("OpFlashAlgoHotVertexThld", &fOpFlashAlgoHotVertexThld);
     fConfigTree->Branch("AdjOpFlashMembraneProjection", &fAdjOpFlashMembraneProjection);
-    fConfigTree->Branch("AdjOpFlashMembraneProjection", &fAdjOpFlashEndCapProjection);
+    fConfigTree->Branch("AdjOpFlashEndCapProjection", &fAdjOpFlashEndCapProjection);
     // fConfigTree->Branch("OpFlashAlgoCentroid", &fOpFlashAlgoCentroid);
     // fConfigTree->Branch("AdjOpFlashTime", &fAdjOpFlashTime);
     fConfigTree->Branch("AdjOpFlashX", &fAdjOpFlashX);

--- a/duneana/SolarNuAna/fcl/SolarNuAna.fcl
+++ b/duneana/SolarNuAna/fcl/SolarNuAna.fcl
@@ -54,13 +54,15 @@ BEGIN_PROLOG
     OpFlashAlgoHotVertexThld:   0.3          # Relative threshold to consider a hit as hot for opflash vertex determination [0-1].
     # OpFlashAlgoCentroid:        false        # Use the centroid computation of the flash based on a likelihood estimation.
 
-    AdjOpFlashX:                100.         # X distance to search for adj. OpFlashes reconstructed in [cm] units.
-    AdjOpFlashY:                100.         # Y distance to search for adj. OpFlashes reconstructed in [cm] units.
-    AdjOpFlashZ:                100.         # Z distance to search for adj. OpFlashes reconstructed in [cm] units.
-    AdjOpFlashMaxPERatioCut:    1.00         # Cut on the maximum OpHit PE contribution to the total OpFlash PE.
-    AdjOpFlashMinPECut:         20.0         # Cut on the minimum OpHit PE. From average bkg rate of ~20 PE per tick.
-    AdjOpFlashMinNHitCut:       3            # Cut on the minimum number of OpHits in the OpFlash.
-    FlashMatchByResidual:       false        # Match flashes by residual. Alternative is to match by MaxFlashPE.
+    AdjOpFlashX:                  100.         # X distance to search for adj. OpFlashes reconstructed in [cm] units.
+    AdjOpFlashY:                  100.         # Y distance to search for adj. OpFlashes reconstructed in [cm] units.
+    AdjOpFlashZ:                  100.         # Z distance to search for adj. OpFlashes reconstructed in [cm] units.
+    AdjOpFlashMaxPERatioCut:      1.00         # Cut on the maximum OpHit PE contribution to the total OpFlash PE.
+    AdjOpFlashMinPECut:           20.0         # Cut on the minimum OpHit PE. From average bkg rate of ~20 PE per tick.
+    AdjOpFlashMinNHitCut:         3            # Cut on the minimum number of OpHits in the OpFlash.
+    AdjOpFlashMembraneProjection: false        # If true, the OpFlash matching is projected on the membrane planes for VD.
+    AdjOpFlashEndCapProjection:   false        # If true, the OpFlash matching is projected on the end cap planes for VD.
+    FlashMatchByResidual:         false        # Match flashes by residual. Alternative is to match by MaxFlashPE.
 
     SaveSignalDaughters:        false        # Save the daughters of the signal particles.
     SaveSignalEDep:             false        # Save the energy deposition of the marley energy deposition in the LAr.
@@ -93,7 +95,9 @@ BEGIN_PROLOG
   solar_nu_ana_vd.XAMembraneY:         743.302
   solar_nu_ana_vd.XAFinalCapZ:         2188.38
   solar_nu_ana_vd.XAStartCapZ:        -96.5
-  solar_nu_ana_vd.ClusterMatchNHit:    3
+  solar_nu_ana_vd.AdjOpFlashX:         200.
+  solar_nu_ana_vd.AdjOpFlashY:         200.
+  solar_nu_ana_vd.AdjOpFlashZ:         200.
 
   solar_nu_ana_vd_1x8x14_optimistic: @local::solar_nu_ana_vd
   solar_nu_ana_vd_1x8x14_optimistic.BackgroundLabelVector: @local::generator_dunevd10kt_1x8x14_3view_30deg_optimistic


### PR DESCRIPTION
This PR aims to optimize the flash-match algorithm for VD by adding the option to only project flashes on the cathode plane, where you expect better S/B.