### PR TITLE
Correctly adapting the order of indices for new CVN

### DIFF
--- a/duneana/AtmoAnalysis/AtmoAnalysis_module.cc
+++ b/duneana/AtmoAnalysis/AtmoAnalysis_module.cc
@@ -360,9 +360,9 @@ void dune::atmoAnalysis::analyze(art::Event const& evt)
         if( !cvnin.failedToGet() && !cvnin->empty()) {
           const std::vector<std::vector<float>> &scores = (*cvnin)[0].fOutput;
 
-          fCVNScoreNC = scores[0][0];
+          fCVNScoreNC = scores[0][2];
           fCVNScoreNuE = scores[0][1];
-          fCVNScoreNuMu = scores[0][2];
+          fCVNScoreNuMu = scores[0][0];
           fCVNScoreProton0 = scores[1][0];
           fCVNScoreProton1 = scores[1][1];
           fCVNScoreProton2 = scores[1][2];

--- a/duneana/CAFMaker/CAFMaker_module.cc
+++ b/duneana/CAFMaker/CAFMaker_module.cc
@@ -790,9 +790,9 @@ namespace caf {
     if( !cvnin.failedToGet() && !cvnin->empty()) {
       if(fIsAtmoCVN){ //Hotfix to take care of the fact that the CVN for atmospherics is storing results in a weird way...
         const std::vector<std::vector<float>> &scores = (*cvnin)[0].fOutput;
-        cvnBranch.nc = scores[0][0];
+        cvnBranch.nc = scores[0][2];
         cvnBranch.nue = scores[0][1];
-        cvnBranch.numu = scores[0][2];
+        cvnBranch.numu = scores[0][0];
       }
 
       else{ //Normal code


### PR DESCRIPTION
Very minor PR to adapt the read out of the CVN scores to the layout imposed bu the change of CVN for the atmospherics