### PR TITLE
Fix operation order to handle continue statement correctly in CAFMaker

### DIFF
--- a/duneana/CAFMaker/CAFMaker_module.cc
+++ b/duneana/CAFMaker/CAFMaker_module.cc
@@ -1107,19 +1107,8 @@ namespace caf {
 
     //Now that all particles are saved, we can convert the parent/daughter fields from Pandora IDs to SR indices
     for(auto &particle : recoParticlesBranch.pandora){
-      //Parent
-      if(particle.parent == -1) continue; //Skipping if primary
-      unsigned int parent_pfpID = particle.parent;
-      //Finding the SR index in the map
-      if(pandoraIDToPFPIdx.count(parent_pfpID) == 0){
-        mf::LogWarning("CAFMaker") << "No SR index found for parent PFP ID " << parent_pfpID;
-        particle.parent = -1; //Setting to -1 to avoid confusion
-      }
-      else{
-        particle.parent = pandoraIDToPFPIdx.at(parent_pfpID);
-      }
 
-    //Daughters
+      //Daughters
       for(auto &daughter_idx : particle.daughters){
         unsigned int daughter_pfpID = daughter_idx;
         //Finding the SR index in the map
@@ -1130,6 +1119,18 @@ namespace caf {
         else{
           daughter_idx = pandoraIDToPFPIdx.at(daughter_pfpID);
         }
+      }
+
+      //Parent
+      if(particle.parent == -1) continue; //Skipping if primary
+      unsigned int parent_pfpID = particle.parent;
+      //Finding the SR index in the map
+      if(pandoraIDToPFPIdx.count(parent_pfpID) == 0){
+        mf::LogWarning("CAFMaker") << "No SR index found for parent PFP ID " << parent_pfpID;
+        particle.parent = -1; //Setting to -1 to avoid confusion
+      }
+      else{
+        particle.parent = pandoraIDToPFPIdx.at(parent_pfpID);
       }
     }
 


### PR DESCRIPTION
Small CAFMaker fix to correctly translate the PFP daughter indices even for primary reco particles.
This minor bug was not visible as in the current setup the reco PFPs are saved in ascending index order hence creating an exact correspondance between the PFP_ID and SR_ID. The current fix allows for the code to work in a general case where this assumption might not hold anymore in the future.