### PR TITLE
Fix wall distance calculation

### DIFF
--- a/duneana/CAFMaker/CAFMaker_module.cc
+++ b/duneana/CAFMaker/CAFMaker_module.cc
@@ -106,7 +106,7 @@ namespace caf {
       double GetVisibleEnergy(art::Ptr<recob::PFParticle> const& pfp, const art::Event &evt) const;
       void FillTruthMatchingAndOverlap(art::Ptr<recob::PFParticle> const& pfp, const art::Event &evt, std::vector<TrueParticleID> &truth, std::vector<float> &truthOverlap) const;
       void FillPFPMetadata(caf::SRPFP &pfpBranch, art::Ptr<recob::PFParticle> const& pfp, const art::Event &evt) const;
-      double GetWallDistance(recob::PFParticle const& pfp, const art::Event &evt) const;
+      double GetWallDistance(art::Ptr<recob::PFParticle> const& pfp, const art::Event &evt) const;
       double GetWallDistance(recob::SpacePoint const& sp) const;
       void ComputeActiveBounds();
       double GetSingleHitsEnergy(art::Event const& evt, int plane) const;
@@ -666,9 +666,9 @@ namespace caf {
 
   //------------------------------------------------------------------------------
 
-  double CAFMaker::GetWallDistance(recob::PFParticle const& pfp, const art::Event &evt) const{
+  double CAFMaker::GetWallDistance(art::Ptr<recob::PFParticle> const& pfp, const art::Event &evt) const{
     double minDist = std::numeric_limits<double>::max();
-    std::vector<art::Ptr<recob::SpacePoint>> spacePoints = dune_ana::DUNEAnaEventUtils::GetSpacePoints(evt, fSpacePointLabel);
+    std::vector<art::Ptr<recob::SpacePoint>> spacePoints = dune_ana::DUNEAnaPFParticleUtils::GetSpacePoints(pfp, evt, fSpacePointLabel);
 
     if(spacePoints.empty()){
       mf::LogWarning("CAFMaker") << "No space points found with label '" << fSpacePointLabel << "'";
@@ -971,7 +971,7 @@ namespace caf {
       pandoraIDToPFPIdx[particle->Self()] = fdIxn.npfps;
 
       FillTruthMatchingAndOverlap(particle, evt, particle_record.truth, particle_record.truthOverlap);
-      particle_record.walldist = GetWallDistance(*particle, evt); //Getting the distance to the wall for this PFP
+      particle_record.walldist = GetWallDistance(particle, evt); //Getting the distance to the wall for this PFP
       particle_record.contained = (particle_record.walldist < fContainedDistThreshold); //Setting the contained flag based on the distance to the wall
 
       //Getting the track and shower objects associated to the PFP

--- a/duneana/CAFMaker/CAFMaker_module.cc
+++ b/duneana/CAFMaker/CAFMaker_module.cc
@@ -135,7 +135,7 @@ namespace caf {
       std::string fTrackLabel;
       std::string fShowerLabel;
       std::string fSpacePointLabel;
-      std::string fContainedDistThreshold;
+      double fContainedDistThreshold;
       std::string fHitLabel;
       std::string fG4Label;
 
@@ -204,7 +204,7 @@ namespace caf {
       fTrackLabel(pset.get< std::string >("TrackLabel")),
       fShowerLabel(pset.get< std::string >("ShowerLabel")),
       fSpacePointLabel(pset.get< std::string >("SpacePointLabel")),
-      fContainedDistThreshold(pset.get< std::string >("ContainedDistThreshold")),
+      fContainedDistThreshold(pset.get< double >("ContainedDistThreshold")),
       fHitLabel(pset.get< std::string >("HitLabel")),
       fG4Label(pset.get< std::string >("G4Label")),
       fEventRecord(new genie::NtpMCEventRecord),

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,7 +248,7 @@ product          version
 cetmodules	 v3_27_04	-	only_for_build
 dunereco         v10_20_09d00
 duneopdet        v10_20_09d00
-duneanaobj       v03_12_00
+duneanaobj       v03_15_00
 end_product_list
 ####################################
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,7 +248,7 @@ product          version
 cetmodules	 v3_27_04	-	only_for_build
 dunereco         v10_20_09d00
 duneopdet        v10_20_09d00
-duneanaobj       v03_15_00
+duneanaobj       v03_12_00
 end_product_list
 ####################################
 


### PR DESCRIPTION
This pull request updates the `GetWallDistance` function in `CAFMaker` to consistently use `art::Ptr<recob::PFParticle>` instead of a reference to `recob::PFParticle`, and updates the logic for retrieving space points to use PFParticle-specific utilities. Additionally, the dependency on `duneanaobj` is updated to a newer version. These changes improve code consistency, correctness, and compatibility.

**Code consistency and correctness:**

* Changed the signature of `GetWallDistance` in both the class declaration and definition to take an `art::Ptr<recob::PFParticle>` instead of a `recob::PFParticle` reference, ensuring consistent use of pointer types throughout the codebase. [[1]](diffhunk://#diff-67f0c0cecd1e516c7b226e6b3a29a1658de2cb2c302300e46619cdc179aa666cL109-R109) [[2]](diffhunk://#diff-67f0c0cecd1e516c7b226e6b3a29a1658de2cb2c302300e46619cdc179aa666cL669-R671) [[3]](diffhunk://#diff-67f0c0cecd1e516c7b226e6b3a29a1658de2cb2c302300e46619cdc179aa666cL974-R974)
* Updated the retrieval of space points in `GetWallDistance` to use `dune_ana::DUNEAnaPFParticleUtils::GetSpacePoints`, which fetches space points associated specifically with the provided PFParticle, improving accuracy.

**Dependency updates:**

* Upgraded the `duneanaobj` dependency from version `v03_12_00` to `v03_15_00` in `product_deps`, ensuring compatibility with recent features and bug fixes.